### PR TITLE
Feature: Response delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,19 @@ MockResponse.plaintext("served three times", lifetime: .multiple(3))
 MockResponse.plaintext("served forever", lifetime: .eternal)
 ```
 
+## Response delivery
+Each response can optionally be given a `delivery` parameter that controls when the response is delivered to the client. The default value of the parameter is `.instant`.
+
+- `.instant`: The response is delivered immediately (default behavior).
+- `.delayed(TimeInterval)`: The response is delayed and delivered after the specified number of seconds.
+
+Example:
+
+```swift
+MockResponse.plaintext("immediate response", delivery: .instant)
+MockResponse.plaintext("delayed response", delivery: .delayed(2.0)) // delivered after 2 seconds
+```
+
 ## Handling unmocked requests
 By default, unmocked requests return a hardcoded 404 response with a small body. You can configure `HTTPMock.unmockedPolicy` to control this behavior, choosing between returning a 404 or allowing the request to pass through to the real network. The default is `notFound`, aka. the hardoced 404 response.
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Path("/user") {
 ## Goals
 - [X] Allow for passthrough networking when mock hasn't been registered for the incoming URL.
 - [X] Let user point to a file that should be served.
-- [ ] Set delay on requests.
+- [X] Set delay on requests.
 - [ ] Let user configure a default "not found" response. Will be used either when no matching mocks are found or if queue is empty.
 - [ ] Create separate instances of `HTTPMock`. The current single instance requires tests to be run in sequence, instead of parallel.
 - [ ] Does arrays in query parameters work? I think they're being overwritten with the current setup.

--- a/Sources/HTTPMock/Models/MockResponse+Delivery.swift
+++ b/Sources/HTTPMock/Models/MockResponse+Delivery.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension MockResponse {
+    public enum Delivery: Hashable {
+        case instant
+        case delayed(TimeInterval)
+    }
+}

--- a/Sources/HTTPMock/Models/MockResponse.swift
+++ b/Sources/HTTPMock/Models/MockResponse.swift
@@ -7,8 +7,9 @@ public struct MockResponse: Hashable {
 
     public let payload: Payload
     public let status: Status
-    public let headers: [String: String]
     public let lifetime: Lifetime
+    public let delivery: Delivery
+    public let headers: [String: String]
 
     // MARK: - Init
 
@@ -16,11 +17,13 @@ public struct MockResponse: Hashable {
         payload: Payload,
         status: Status = .ok,
         lifetime: Lifetime = .single,
+        delivery: Delivery = .instant,
         headers: [String: String] = [:]
     ) {
         self.payload = payload
         self.status = status
         self.lifetime = lifetime
+        self.delivery = delivery
 
         if let contentType = payload.contentType {
             // Merge the headers, allowing the user to overwrite any we set.
@@ -40,6 +43,7 @@ extension MockResponse {
         _ payload: T,
         status: Status = .ok,
         lifetime: Lifetime = .single,
+        delivery: Delivery = .instant,
         headers: [String: String] = [:],
         jsonEncoder: JSONEncoder = .mockDefault
     ) throws -> MockResponse {
@@ -48,6 +52,7 @@ extension MockResponse {
             payload: .data(data, contentType: "application/json"),
             status: status,
             lifetime: lifetime,
+            delivery: delivery,
             headers: headers
         )
     }
@@ -56,6 +61,7 @@ extension MockResponse {
         _ payload: [String: Any],
         status: Status = .ok,
         lifetime: Lifetime = .single,
+        delivery: Delivery = .instant,
         headers: [String: String] = [:]
     ) throws -> MockResponse {
         let data = try JSONSerialization.data(withJSONObject: payload)
@@ -63,6 +69,7 @@ extension MockResponse {
             payload: .data(data, contentType: "application/json"),
             status: status,
             lifetime: lifetime,
+            delivery: delivery,
             headers: headers
         )
     }
@@ -71,6 +78,7 @@ extension MockResponse {
         _ payload: String,
         status: Status = .ok,
         lifetime: Lifetime = .single,
+        delivery: Delivery = .instant,
         headers: [String: String] = [:]
     ) -> MockResponse {
         let data = Data(payload.utf8)
@@ -78,6 +86,7 @@ extension MockResponse {
             payload: .data(data, contentType: "text/plain"),
             status: status,
             lifetime: lifetime,
+            delivery: delivery,
             headers: headers
         )
     }
@@ -85,12 +94,14 @@ extension MockResponse {
     public static func empty(
         status: Status = .ok,
         lifetime: Lifetime = .single,
+        delivery: Delivery = .instant,
         headers: [String: String] = [:]
     ) -> MockResponse {
         Self.init(
             payload: .empty,
             status: status,
             lifetime: lifetime,
+            delivery: delivery,
             headers: headers
         )
     }
@@ -111,6 +122,7 @@ extension MockResponse {
         in bundle: Bundle = .main,
         status: Status = .ok,
         lifetime: Lifetime = .single,
+        delivery: Delivery = .instant,
         headers: [String: String] = [:],
         contentType: String? = nil
     ) -> MockResponse {
@@ -121,6 +133,7 @@ extension MockResponse {
             url: url,
             status: status,
             lifetime: lifetime,
+            delivery: delivery,
             headers: headers,
             contentType: contentType
         )
@@ -138,6 +151,7 @@ extension MockResponse {
         url: URL,
         status: Status = .ok,
         lifetime: Lifetime = .single,
+        delivery: Delivery = .instant,
         headers: [String: String] = [:],
         contentType: String? = nil
     ) -> MockResponse {
@@ -154,6 +168,7 @@ extension MockResponse {
             payload: .data(data, contentType: contentType),
             status: status,
             lifetime: lifetime,
+            delivery: delivery,
             headers: headers
         )
     }
@@ -195,6 +210,7 @@ extension MockResponse {
             payload: self.payload,
             status: self.status,
             lifetime: lifetime,
+            delivery: delivery,
             headers: extra.mergedInOther(self.headers)
         )
     }
@@ -204,6 +220,7 @@ extension MockResponse {
             payload: payload,
             status: status,
             lifetime: newLifetime,
+            delivery: delivery,
             headers: headers
         )
     }


### PR DESCRIPTION
# Why?
Responses are currently delivered immediately, but one might want to delay a response for `n` seconds. Immediate delivery is still the default, but this adds support for delaying the response.

# What?
- Add `MockResponse.Delivery`
  - Has cases `.instant` and `.delayed(TimeInterval)`
- Add tests

# Show me

```swift
HTTPMock.shared.addResponses(
    forPath: "/root",
    responses: [
        .empty(delivery: .instant),     // Delivered immediately on request.
        .empty(delivery: .delayed(2.0)) // Response delivery is delayed for 2 seconds.
    ]
)
```