### PR TITLE
Feature: Support for multiple instances of `HTTPMock`

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,4 +21,4 @@ jobs:
         run: swift build
 
       - name: Test
-        run: swift test --no-parallel
+        run: swift test --parallel

--- a/HTTPMock.xctestplan
+++ b/HTTPMock.xctestplan
@@ -13,7 +13,6 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:",
         "identifier" : "HTTPMockTests",

--- a/Sources/HTTPMock/Extensions/URLSession+Extensions.swift
+++ b/Sources/HTTPMock/Extensions/URLSession+Extensions.swift
@@ -1,0 +1,22 @@
+import Foundation
+import ObjectiveC.runtime
+
+private var MockIdentifierKey: UInt8 = 0
+
+extension URLSession {
+    /// Attach/read a UUID on a URLSession instance.
+    var mockIdentifier: UUID? {
+        get { objc_getAssociatedObject(self, &MockIdentifierKey) as? UUID }
+        set { objc_setAssociatedObject(self, &MockIdentifierKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    static func identifiedSession(with identifier: UUID) -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [HTTPMockURLProtocol.self]
+
+        let urlSession = URLSession(configuration: configuration)
+        urlSession.mockIdentifier = identifier
+
+        return urlSession
+    }
+}

--- a/Sources/HTTPMock/HTTPMock+ResultBuilder.swift
+++ b/Sources/HTTPMock/HTTPMock+ResultBuilder.swift
@@ -17,7 +17,7 @@ extension HTTPMock {
                     queryItems: registration.queryItems,
                     queryMatching: registration.queryMatching ?? .exact
                 )
-                HTTPMockURLProtocol.add(responses: finalResponses, forKey: key)
+                HTTPMockURLProtocol.add(responses: finalResponses, forKey: key, forMockIdentifier: mockIdentifier)
             }
         }
     }
@@ -38,7 +38,7 @@ extension HTTPMock {
                 queryItems: registration.queryItems,
                 queryMatching: registration.queryMatching ?? .exact
             )
-            HTTPMockURLProtocol.add(responses: finalResponses, forKey: key)
+            HTTPMockURLProtocol.add(responses: finalResponses, forKey: key, forMockIdentifier: mockIdentifier)
         }
     }
 

--- a/Sources/HTTPMock/HTTPMock.swift
+++ b/Sources/HTTPMock/HTTPMock.swift
@@ -12,7 +12,11 @@ public final class HTTPMock {
 
     let mockIdentifier: UUID
 
-    init(identifier mockIdentifier: UUID = UUID()) {
+    public convenience init() {
+        self.init(identifier: UUID())
+    }
+
+    required init(identifier mockIdentifier: UUID) {
         self.mockIdentifier = mockIdentifier
         urlSession = URLSession.identifiedSession(with: mockIdentifier)
     }

--- a/Sources/HTTPMock/HTTPMock.swift
+++ b/Sources/HTTPMock/HTTPMock.swift
@@ -6,8 +6,8 @@ public final class HTTPMock {
     public var defaultDomain = "example.com"
 
     public var unmockedPolicy: UnmockedPolicy {
-        get { HTTPMockURLProtocol.unmockedPolicy }
-        set { HTTPMockURLProtocol.unmockedPolicy = newValue }
+        get { HTTPMockURLProtocol.getUnmockedPolicy(for: mockIdentifier) }
+        set { HTTPMockURLProtocol.setUnmockedPolicy(for: mockIdentifier, newValue) }
     }
 
     let mockIdentifier: UUID

--- a/Sources/HTTPMock/HTTPMock.swift
+++ b/Sources/HTTPMock/HTTPMock.swift
@@ -29,7 +29,8 @@ public final class HTTPMock {
             forHost: defaultDomain,
             path: normalized(path),
             queryItems: queryItems,
-            queryMatching: queryMatching
+            queryMatching: queryMatching,
+            forMockIdentifier: mockIdentifier
         )
     }
 
@@ -46,7 +47,8 @@ public final class HTTPMock {
             forHost: host,
             path: normalized(path),
             queryItems: queryItems,
-            queryMatching: queryMatching
+            queryMatching: queryMatching,
+            forMockIdentifier: mockIdentifier
         )
     }
 
@@ -57,12 +59,12 @@ public final class HTTPMock {
 
     /// Clear all queues – basically a reset.
     public func clearQueues() {
-        HTTPMockURLProtocol.clearQueues()
+        HTTPMockURLProtocol.clearQueues(mockIdentifier: mockIdentifier)
     }
 
     /// Clear the response queue for a single host.
     public func clearQueue(forHost host: String) {
-        HTTPMockURLProtocol.clearQueue(forHost: host)
+        HTTPMockURLProtocol.clearQueue(forHost: host, mockIdentifier: mockIdentifier)
     }
 
     /// Makes sure all paths are prefixed with `/`. We need this for consistency when looking up responses from the queue.

--- a/Sources/HTTPMock/HTTPMock.swift
+++ b/Sources/HTTPMock/HTTPMock.swift
@@ -10,10 +10,11 @@ public final class HTTPMock {
         set { HTTPMockURLProtocol.unmockedPolicy = newValue }
     }
 
-    private init() {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [HTTPMockURLProtocol.self]
-        urlSession = URLSession(configuration: configuration)
+    let mockIdentifier: UUID
+
+    init(identifier mockIdentifier: UUID = UUID()) {
+        self.mockIdentifier = mockIdentifier
+        urlSession = URLSession.identifiedSession(with: mockIdentifier)
     }
 
     /// Queue responses for a given path (e.g. "/some-path") for host in `defaultDomain`. Each request will pop the next response.

--- a/Tests/HTTPMockTests/HTTPMockResultBuilderTests.swift
+++ b/Tests/HTTPMockTests/HTTPMockResultBuilderTests.swift
@@ -5,8 +5,9 @@ import Foundation
 struct HTTPMockResultBuilderTests {
     let httpMock: HTTPMock
     let identifier: UUID
+
     var mockQueues: [HTTPMockURLProtocol.Key: [MockResponse]] {
-        HTTPMockURLProtocol.queues[identifier] ?? [:]
+        HTTPMockURLProtocol.getQueue(for: identifier)
     }
 
     init() {

--- a/Tests/HTTPMockTests/HTTPMockResultBuilderTests.swift
+++ b/Tests/HTTPMockTests/HTTPMockResultBuilderTests.swift
@@ -4,14 +4,15 @@ import Foundation
 
 struct HTTPMockResultBuilderTests {
     let httpMock: HTTPMock
+    let identifier: UUID
     var mockQueues: [HTTPMockURLProtocol.Key: [MockResponse]] {
-        HTTPMockURLProtocol.queues
+        HTTPMockURLProtocol.queues[identifier] ?? [:]
     }
 
     init() {
-        httpMock = HTTPMock.shared
+        identifier = UUID()
+        httpMock = HTTPMock(identifier: identifier)
         httpMock.defaultDomain = "example.com"
-        HTTPMock.shared.clearQueues()
         HTTPMockLog.level = .trace
     }
 

--- a/Tests/HTTPMockTests/HTTPMockTests.swift
+++ b/Tests/HTTPMockTests/HTTPMockTests.swift
@@ -428,8 +428,8 @@ struct HTTPMockTests {
     @Test
     func delivery_appliesPerResponse_inFifoOrder() async throws {
         let key = createMockKey(path: "/delay-sequence")
-        httpMock.addResponse(.plaintext("requested-first-but-delivered-second", delivery: .delayed(0.2)), for: key)
-        httpMock.addResponse(.plaintext("requested-second-but-delivered-first", delivery: .delayed(0.1)), for: key)
+        httpMock.addResponse(.plaintext("requested-first-but-delivered-second", delivery: .delayed(0.5)), for: key)
+        httpMock.addResponse(.plaintext("requested-second-but-delivered-first", delivery: .instant), for: key)
 
 
         let url = try #require(URL(string: "https://example.com/delay-sequence"))

--- a/Tests/HTTPMockTests/HTTPMockTests.swift
+++ b/Tests/HTTPMockTests/HTTPMockTests.swift
@@ -4,14 +4,15 @@ import Foundation
 
 struct HTTPMockTests {
     let httpMock: HTTPMock
+    let identifier: UUID
     var mockQueues: [HTTPMockURLProtocol.Key: [MockResponse]] {
-        HTTPMockURLProtocol.queues
+        HTTPMockURLProtocol.queues[identifier] ?? [:]
     }
 
     init() {
-        httpMock = HTTPMock.shared
+        identifier = UUID()
+        httpMock = HTTPMock(identifier: identifier)
         httpMock.defaultDomain = "example.com"
-        HTTPMock.shared.clearQueues()
         HTTPMockLog.level = .trace
     }
 


### PR DESCRIPTION
# Why?
One painpoint in the current setup is that there can only exist one instance of `HTTPMock` at a time, because of the way the response queues are handled. This is a pretty big limit, especially when it forces us to run tests using `HTTPMock` in sequence.

# How
With this new setup the user can create several instances of `HTTPMock`, each with their own queue and `URLSession`. The way this works is to assign a known identifier (`UUID`) to both `HTTPMock` and its `URLSession`. The singleton `HTTPMock.shared` still exists for convenience.

`HTTPMockURLProtocol`'s queue looks like this:

| Before | After |
| - | - |
| `[Key: [MockResponse]]` | `[UUID: [Key: [MockResponse]]]` |

When a request comes in `HTTPMockURLProtocol` will look at the identifier on the `URLSessionTask`'s `URLSession` and use this to look up the queue in question.

When registering new responses the identifier has to be provided, so the responses are placed in the correct queue.

To avoid race conditions all reads/writes to/from the queue now happens within a lock.

# What?
- Allow `HTTPMock` to accept an identifier on instantiation.
- Assign this identifier to the instance's `URLSession`.
- Improve `HTTPMockURLProtocol` to identify which queue to use, based on this identifier.
  - Coming as a parameter when inserting/removing.
  - Reading from `URLSession` on incoming request.
- Update/add tests and let them run in parallel.