### PR TITLE
Feature: New unmocked policies

### DIFF
--- a/Sources/HTTPMock/Models/UnmockedPolicy.swift
+++ b/Sources/HTTPMock/Models/UnmockedPolicy.swift
@@ -11,4 +11,8 @@ public enum UnmockedPolicy {
     /// Let the request pass through to the internet.
     /// Useful for integration tests where you want to mock some responses, but let others hit actual network.
     case passthrough
+    
+    /// Perform a `fatalError()` call to abruptly end the running app/test.
+    /// Useful for strict testing of your networking.
+    case fatalError
 }

--- a/Sources/HTTPMock/Models/UnmockedPolicy.swift
+++ b/Sources/HTTPMock/Models/UnmockedPolicy.swift
@@ -5,6 +5,9 @@ public enum UnmockedPolicy {
     /// Return a hardcoded "Not found" message, along with HTTP status 404.
     case notFound
 
+    /// Return a user-defined mocked response.
+    case mock(MockResponse)
+
     /// Let the request pass through to the internet.
     /// Useful for integration tests where you want to mock some responses, but let others hit actual network.
     case passthrough

--- a/Tests/HTTPMockTests/HTTPMockFatalErrorTests.swift
+++ b/Tests/HTTPMockTests/HTTPMockFatalErrorTests.swift
@@ -1,0 +1,84 @@
+import Testing
+import Foundation
+@testable import HTTPMock
+
+/// These tests are separated from the rest, so we can run them in sequence. We need to do this, because they all set the `unmockedPolicy` to `fatalError`.
+/// Having them run in parallel will cause issues, since `HTTPMockURLProtocol.fatalErrorClosure` is shared and will be reset between each call to an unmocked URL
+/// where the policy is `fatalError.`
+@Suite(.serialized)
+struct HTTPMockFatalErrorTests {
+    let httpMock: HTTPMock
+
+    init() {
+        httpMock = HTTPMock()
+        HTTPMockLog.level = .trace
+    }
+
+    @Test
+    func unmockedPolicy_fatalError_callsFatalErrorClosure() async throws {
+        var fatalErrorCalled = false
+
+        // Set up the test closure
+        HTTPMockURLProtocol.fatalErrorClosure = {
+            fatalErrorCalled = true
+        }
+
+        // Configure fatal error policy
+        httpMock.unmockedPolicy = .fatalError
+        let url = try #require(URL(string: "https://example.com/fatal-test"))
+
+        // The request should trigger our test closure instead of actually calling fatalError
+        _ = try? await httpMock.urlSession.data(from: url)
+        #expect(fatalErrorCalled == true)
+        #expect(HTTPMockURLProtocol.fatalErrorClosure == nil) // Should be reset after use
+    }
+
+    @Test
+    func unmockedPolicy_fatalError_resetsClosureAfterCall() async throws {
+        var firstCallMade = false
+        var secondCallMade = false
+
+        // Set up the test closure for first call
+        HTTPMockURLProtocol.fatalErrorClosure = {
+            firstCallMade = true
+        }
+        httpMock.unmockedPolicy = .fatalError
+        let url = try #require(URL(string: "https://example.com/fatal-reset-test"))
+
+        // First unmocked request should trigger closure
+        _ = try? await httpMock.urlSession.data(from: url)
+        #expect(firstCallMade == true)
+        #expect(HTTPMockURLProtocol.fatalErrorClosure == nil)
+
+        // Set up a different closure for second call
+        HTTPMockURLProtocol.fatalErrorClosure = {
+            secondCallMade = true
+        }
+
+        // Second unmocked request should trigger the new closure
+        _ = try? await httpMock.urlSession.data(from: url)
+        #expect(secondCallMade == true)
+        #expect(HTTPMockURLProtocol.fatalErrorClosure == nil)
+    }
+
+    @Test
+    func unmockedPolicy_fatalError_switchingFromOtherPolicies() async throws {
+        let url = try #require(URL(string: "https://example.com/policy-to-fatal"))
+
+        // Start with notFound policy
+        httpMock.unmockedPolicy = .notFound
+        let (_, response1) = try await httpMock.urlSession.data(from: url)
+        #expect(response1.httpStatusCode == 404)
+
+        // Switch to fatalError policy
+        var fatalErrorCalled = false
+        HTTPMockURLProtocol.fatalErrorClosure = {
+            fatalErrorCalled = true
+        }
+        httpMock.unmockedPolicy = .fatalError
+
+        // Should now trigger fatal error behavior
+        _ = try? await httpMock.urlSession.data(from: url)
+        #expect(fatalErrorCalled == true)
+    }
+}


### PR DESCRIPTION
# Why?
Currently the user is not able to provide their own response for unmocked incoming requests – the only option is a hardcoded 404 and passthrough to real network.

The changes in this PR adds these two cases to `UnmockPolicy`:
- `.mock(MockResponse)`
- `.fatalError`

#### `UnmockedPolicy.mock(MockResponse)`
This one lets the user provide their own `MockResponse` for all unmocked requests. The single response will be used for all incoming requests where a mock can't be found – either because none is registered, or the queue is empty.

#### `UnmockedPolicy.fatalError`
This is an addition for stricter testing which will call `fatalError()` if there aren't any mocks for an incoming request. Usecases will be to i.e. create a hard assumption that all network requests are mocked or handled.

Closes #7 

# What?
- Add cases `.mock(MockResponse)` and `.fatalError` to `UnmockedPolicy`.
- Pull out shared code for sending response in `HTTPURLMockProtocol`.
- Add tests.
- Update README.

# Show me

```swift
let httpMock = HTTPMock()

// Set your own response to unmocked requests.
httpMock.unmockedPolicy = .mock(.plaintext("Ouchie!"))

// Force a `fatalError()` call on incoming unmocked requests.
httpMock.unmockedPolicy = .fatalError
```